### PR TITLE
Fix: Configure Vite root to resolve index.html

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  root: path.resolve(import.meta.dirname, "client"),
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
The Vite build process was failing with the error "Could not resolve entry module 'index.html'". This was because the `index.html` file is located in `client/index.html`, but Vite was looking for it in the project root by default.

This commit fixes the issue by:
1. Setting the `root` option in `vite.config.ts` to point to the `client` directory.
2. Ensuring that `build.outDir` and `resolve.alias` paths are correctly defined relative to the project root after the `root` change.

This change allows Vite to correctly locate `index.html` and proceed with the build.