### PR TITLE
Add Netlify redirect for /api/* to function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,9 @@
 [functions]
   directory = "dist" # Your server/index.ts is bundled to dist/index.js
   node_bundler = "esbuild" # Explicitly tell Netlify to use esbuild for functions
+
+# Redirect rule to proxy /api/* requests to the index function
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/index/:splat"
+  status = 200


### PR DESCRIPTION
Adds a redirect rule to netlify.toml to proxy requests from /api/* to the /.netlify/functions/index/:splat endpoint. This should resolve the 404 errors when trying to reach the API endpoints for the contact form.