### PR TITLE
Consolidate Netlify redirects in _redirects file

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -1,1 +1,2 @@
-/*  /index.html   200
+/api/*  /.netlify/functions/index/:splat  200
+/*      /index.html                       200

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,9 +5,3 @@
 [functions]
   directory = "dist" # Your server/index.ts is bundled to dist/index.js
   node_bundler = "esbuild" # Explicitly tell Netlify to use esbuild for functions
-
-# Redirect rule to proxy /api/* requests to the index function
-[[redirects]]
-  from = "/api/*"
-  to = "/.netlify/functions/index/:splat"
-  status = 200


### PR DESCRIPTION
- Moved API proxy rule for /api/* to client/public/_redirects and placed it before the SPA fallback rule to ensure correct processing order.
- Removed the redundant API proxy rule from netlify.toml.

This change addresses the issue where the SPA fallback rule in _redirects was taking precedence over the API proxy rule in netlify.toml, causing 404 errors for API calls.