### PR TITLE
Implement scroll to top on navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,11 +11,13 @@ import Community from "@/pages/community";
 import Coaching from "@/pages/coaching";
 import Contact from "@/pages/contact";
 import NotFound from "@/pages/not-found";
+import ScrollToTop from "@/components/ScrollToTop"; // Added import
 
 function Router() {
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
+      <ScrollToTop /> {/* Added component instance */}
       <main className="flex-1">
         <Switch>
           <Route path="/" component={Home} />

--- a/client/src/components/ScrollToTop.tsx
+++ b/client/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
+
+const ScrollToTop = () => {
+  const [pathname] = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null; // This component does not render anything
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
- Created a new ScrollToTop component that uses wouter's useLocation hook and React's useEffect hook to call window.scrollTo(0, 0) whenever the route pathname changes.
- Integrated the ScrollToTop component into App.tsx within the Router, ensuring it applies to all routes.

This change ensures that navigating to a new page or view within the SPA will reset the scroll position to the top.