### PR TITLE
Fix: Ensure navigation scrolls to top of page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,10 +11,12 @@ import Community from "@/pages/community";
 import Coaching from "@/pages/coaching";
 import Contact from "@/pages/contact";
 import NotFound from "@/pages/not-found";
+import ScrollToTop from "./components/ScrollToTop"; // Added import
 
 function Router() {
   return (
     <div className="min-h-screen flex flex-col">
+      <ScrollToTop /> {/* Added component here */}
       <Navbar />
       <main className="flex-1">
         <Switch>

--- a/client/src/components/ScrollToTop.tsx
+++ b/client/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
+
+const ScrollToTop = () => {
+  const [pathname] = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null; // This component does not render anything
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Previously, navigating to new pages via wouter's Link components or setLocation function would sometimes result in the page opening scrolled to the middle.

This commit introduces a `ScrollToTop` component that utilizes wouter's `useLocation` hook and React's `useEffect` hook. On every change of the route pathname, `window.scrollTo(0, 0)` is called.

The `ScrollToTop` component has been integrated into `App.tsx` so that it applies globally to all routes, ensuring a consistent user experience where pages always load at the very top.